### PR TITLE
Add safe-check to ResourcesNode

### DIFF
--- a/src/nodeTypes/ResourcesNode.js
+++ b/src/nodeTypes/ResourcesNode.js
@@ -7,7 +7,7 @@ class ResourcesNode extends ObjectNode {
     }
 
     findWrappedResource(resourceLogicalId) {
-        return this.wrappedObject[resourceLogicalId];
+        return this.wrappedObject ? this.wrappedObject[resourceLogicalId] : undefined;
     }
 
     getResolvedArn(resourceLogicalId) {


### PR DESCRIPTION
We stumbled upon a strange error `TypeError: Cannot read property 'GraphQlApi' of undefined` in https://github.com/bboure/serverless-appsync-simulator/issues/20 and after some digging I've found out that it's caused by `cfn-resolver-lib`.

This issue happens when "Resources" are empty thus `addChild ` is never called [thus this.wrappedObject is undefined](https://github.com/robessog/cfn-resolver-lib/blob/68a990808c027a84757a19792e8c7d9b309de992/src/nodeTypes/ObjectNode.js#L7-L13) and thus when reading property of undefined, we get an error.

But I'm not sure if this fix doesn't break some other functionally, because this lib is not that simple to understand. 