### PR TITLE
Adds safe-check for convertedResources in FnGetAttNode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cfn-resolver-lib",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/nodeTypes/FnGetAttNode.js
+++ b/src/nodeTypes/FnGetAttNode.js
@@ -14,7 +14,7 @@ class FnGetAttNode extends ArrayNode {
         const resourceLogicalId = this.directDependencies[0].evaluate();
         const attrPath = this.directDependencies[1].evaluate();
 
-        const resource = this.convertedResources.findWrappedResource(resourceLogicalId);
+        const resource = this.convertedResources ? this.convertedResources.findWrappedResource(resourceLogicalId): undefined;
 
         // Handle ARN resolutions if resource is present in the template
         if (attrPath === "Arn" && resource) {


### PR DESCRIPTION
We came upon this [issue](https://github.com/bboure/serverless-appsync-simulator/issues/48) in `serverless-appsync-simulator`.  Getting error `AppSync Simulator: TypeError: Cannot read property 'findWrappedResource' of undefined` and thus the simulator fails to start.

Response from @bboure and a little investigation showed the problem lay in `cfn-resolver-lib`.  This issue happens when `Resources` are empty and thus [`this.convertedResources`](https://github.com/robessog/cfn-resolver-lib/blob/master/src/nodeTypes/FnGetAttNode.js#L9) is `undefined`, hence [this](https://github.com/robessog/cfn-resolver-lib/blob/master/src/nodeTypes/FnGetAttNode.js#L17) errors when attempting to read property of undefined.

I'm unsure if this fix won't break other functionality due to this libs complexity, but I've checked it passes all current unit tests and resolves my issue in `serverless-appsync-simulator`.

Also updates own version in `package-lock.json` (happened automatically running `npm install`)

This issue is very similar to this previously resolved [issue](https://github.com/robessog/cfn-resolver-lib/pull/70)